### PR TITLE
Replace if-else with guard clauses

### DIFF
--- a/src/main/java/Remy/command/DeadlineCommand.java
+++ b/src/main/java/Remy/command/DeadlineCommand.java
@@ -37,12 +37,12 @@ public class DeadlineCommand extends Command {
         // Create a Matcher to check if the input matches the pattern
         Matcher matcher = pattern.matcher(input);
 
-        if (matcher.matches()) {
-            this.taskName = matcher.group(1);
-            this.dueDate = matcher.group(2);
-        } else {
+        if (!matcher.matches()) {
             throw new ChatbotException("missing info or wrong format");
         }
+
+        this.taskName = matcher.group(1);
+        this.dueDate = matcher.group(2);
     }
 
 

--- a/src/main/java/Remy/command/DeleteCommand.java
+++ b/src/main/java/Remy/command/DeleteCommand.java
@@ -23,27 +23,20 @@ public class DeleteCommand extends Command {
             throw new ChatbotException("missing info lah.");
         }
         int index = Integer.parseInt(input.substring(7)) - 1;
-        if (index >= 0) {
-            this.index = index;
+
+        if (index <= 0) {
+            throw new ChatbotException("invalid number bro");
         }
 
-    }
-
-    @Override
-    public boolean isExit() {
-        return false;
+        this.index = index;
     }
 
     @Override
     public String execute(TaskList taskList, Ui ui, Storage storage) throws ChatbotException {
-        try {
-            String task = taskList.get(this.index).toString();
-            taskList.remove(this.index);
-            String content = "Done. Can you don't be so troublesome?\n" + task;
-            storage.save(taskList);
-            return content;
-        } catch (ChatbotException e) {
-            return "Cannot execute delete command: " + e.getMessage();
-        }
+        String task = taskList.get(this.index).toString();
+        taskList.remove(this.index);
+        String content = "Done. Can you don't be so troublesome?\n" + task;
+        storage.save(taskList);
+        return content;
     }
 }


### PR DESCRIPTION
Commands use if-else blocks to check that index is valid.

If-else blocks can make code less readable as they obscure the happy path. In contrast, guard clauses contribute to high code quality as they make the happy path more prominent.

Let's replace all if-else checks with guard clauses.